### PR TITLE
Add concurrent access flag to the PlexusIoProxyResourceCollection

### DIFF
--- a/src/main/java/org/codehaus/plexus/components/io/resources/PlexusIoCompressedFileResourceCollection.java
+++ b/src/main/java/org/codehaus/plexus/components/io/resources/PlexusIoCompressedFileResourceCollection.java
@@ -186,4 +186,9 @@ public abstract class PlexusIoCompressedFileResourceCollection
         File f = getFile();
         return f == null ? PlexusIoResource.UNKNOWN_MODIFICATION_DATE : f.lastModified();
     }
+
+    public boolean isConcurrentAccessSupported() {
+	// There is a single resource in the collection so it is safe
+	return true;
+    }
 }

--- a/src/main/java/org/codehaus/plexus/components/io/resources/PlexusIoFileResourceCollection.java
+++ b/src/main/java/org/codehaus/plexus/components/io/resources/PlexusIoFileResourceCollection.java
@@ -308,4 +308,8 @@ public class PlexusIoFileResourceCollection
             return result.iterator();
         }
     }
+
+    public boolean isConcurrentAccessSupported() {
+	return true;
+    }
 }

--- a/src/main/java/org/codehaus/plexus/components/io/resources/PlexusIoResourceCollection.java
+++ b/src/main/java/org/codehaus/plexus/components/io/resources/PlexusIoResourceCollection.java
@@ -91,5 +91,23 @@ public interface PlexusIoResourceCollection extends Iterable<PlexusIoResource>
      */
     PlexusIoResource resolve( PlexusIoResource resource ) throws IOException;
 
+    /**
+     * Indicates if this collection supports concurrent access to its resources.
+     * <p>Some resource collections (like tar files) may not support efficient random access
+     * or seek operation so implementations that represent such collections may not be able
+     * to provide concurrent access to its resources. If implementation returns {@code false},
+     * then it is not safe to access its methods and resources in concurrent fashion.
+     * For example it is not safe to read from two resources in two concurrent threads,
+     * to read a resource and iterate over the iterator returned by {@link #getResources()}
+     * in two concurrent threads, etc.
+     * <p>Please note that this method indicates concurrent support only for the collection,
+     * not for the individual resources. This means there is no guarantee that
+     * the resources returned by {@link #resolve(PlexusIoResource)} or the input stream
+     * returned by {@link #getInputStream(PlexusIoResource)} are thread-safe,
+     * even if {@code true} is returned.
+     * @return {@code true} if this collection supports concurrent access,
+     *   otherwise {@code false}
+     */
+    boolean isConcurrentAccessSupported();
 
 }

--- a/src/main/java/org/codehaus/plexus/components/io/resources/proxy/PlexusIoProxyResourceCollection.java
+++ b/src/main/java/org/codehaus/plexus/components/io/resources/proxy/PlexusIoProxyResourceCollection.java
@@ -212,4 +212,8 @@ public class PlexusIoProxyResourceCollection
             ((EncodingSupported)src).setEncoding( charset );
         }
     }
+
+    public boolean isConcurrentAccessSupported() {
+	return src.isConcurrentAccessSupported();
+    }
 }

--- a/src/test/java/org/codehaus/plexus/components/io/resources/AbstractPlexusIoResourceCollectionTest.java
+++ b/src/test/java/org/codehaus/plexus/components/io/resources/AbstractPlexusIoResourceCollectionTest.java
@@ -33,6 +33,10 @@ public class AbstractPlexusIoResourceCollectionTest
                 throw new UnsupportedOperationException();
             }
 
+	    public boolean isConcurrentAccessSupported() {
+		return true;
+	    }
+
         };
 
         sut.setStreamTransformer( new InputStreamTransformer()

--- a/src/test/java/org/codehaus/plexus/components/io/resources/proxy/PlexusIoProxyResourceCollectionTest.java
+++ b/src/test/java/org/codehaus/plexus/components/io/resources/proxy/PlexusIoProxyResourceCollectionTest.java
@@ -121,6 +121,10 @@ public class PlexusIoProxyResourceCollectionTest
                 {
                     throw new UnsupportedOperationException();
                 }
+
+		public boolean isConcurrentAccessSupported() {
+		    return true;
+		}
             } );
         Iterator<PlexusIoResource> resources1 = resCol.getResources();
         resources1.hasNext();


### PR DESCRIPTION
Plexus Archiver added support for concurrent zip creation that does lead to a regression - adding the content of tar archive to a zip file is no longer possible as the tar archive is not thread safe. There are two bug reports about that: codehaus-plexus/plexus-archiver#10 and [MASSEMBLY-789](https://issues.apache.org/jira/browse/MASSEMBLY-789)

There are two ways to solve this - either the tar code must be made thread safe or the zip archiver should be able to add some of the entries in non-concurrent way.

Tar archives does not have indexes for entries. And even if they did (one could be build while iterating over the entries) you can't just skip to the location of the entry as usually the tar are archived. You must decompress the tar file (at least until the entry) for every entry. Another possibility is to unpack the tar archive to a temporary location and then build the index while iterating over the entries. This index could be used to access directly the entry of the unpacked tar file.
Both of this solutions require a lot of unnecessary CPU and/or IO usage so I think the end result will be worse performance even with the concurrent zip utilization of all available cores.

I think the better solution is to acknowledge that there are some resource collections that should be accessed in non-concurrent way so the concurrent jar creator (or any other code that works with such collections) access them in single thread manner. The big question is how. With this pull request I'm proposing to add a new method to the `PlexusIoProxyResourceCollection` interface. What do you think?

I also considered adding new marker interface. But there is heavy usage of proxies for resources and resource collections and I think even if implemented would not result in good and easy to maintain code.