### PR TITLE
Support following symbolic links to files

### DIFF
--- a/src/main/java/org/codehaus/plexus/components/io/attributes/FileAttributes.java
+++ b/src/main/java/org/codehaus/plexus/components/io/attributes/FileAttributes.java
@@ -71,8 +71,13 @@ public class FileAttributes
                            @Nonnull Map<Integer, String> groupCache )
         throws IOException
     {
+        this( file.toPath(), userCache, groupCache );
+    }
 
-        Path path = file.toPath();
+    public FileAttributes( @Nonnull Path path, @Nonnull Map<Integer, String> userCache,
+                           @Nonnull Map<Integer, String> groupCache )
+        throws IOException
+    {
         Set<String> views = path.getFileSystem().supportedFileAttributeViews();
         String names;
         if ( views.contains( "unix" ) )

--- a/src/main/java/org/codehaus/plexus/components/io/resources/PlexusIoFileResourceCollection.java
+++ b/src/main/java/org/codehaus/plexus/components/io/resources/PlexusIoFileResourceCollection.java
@@ -27,6 +27,7 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -158,8 +159,13 @@ public class PlexusIoFileResourceCollection
         {
             String sourceDir = name.replace( '\\', '/' );
             File f = new File( dir, sourceDir );
+            Path p = f.toPath();
+            if ( isFollowingSymLinks() )
+            {
+                p = p.toRealPath();
+            }
 
-            FileAttributes fattrs = new FileAttributes( f, cache1, cache2 );
+            FileAttributes fattrs = new FileAttributes( p, cache1, cache2 );
             PlexusIoResourceAttributes attrs = mergeAttributes( fattrs, fattrs.isDirectory() );
 
             String remappedName = getName( name );


### PR DESCRIPTION
This implements the necessary support to allow plexus-archiver to archive the contents of symlinks (instead of the symbolic links themselves), depending on the (already-extant) follow-symlinks flag.

Closes: https://github.com/codehaus-plexus/plexus-io/issues/37

I’ve tested this in [a patch against 3.2.0](https://github.com/tarent/plexus-io/tree/plexus-io-3.2.0-follow-symlinks) which _slightly_ differs from this patch against git master, but I believe there to be no issues.