### PR TITLE
Replace `FileUtils.deleteDirectory(File)` with JDK provided API

### DIFF
--- a/src/test/java/org/codehaus/plexus/components/io/filemappers/ResourcesTest.java
+++ b/src/test/java/org/codehaus/plexus/components/io/filemappers/ResourcesTest.java
@@ -67,7 +67,7 @@ public class ResourcesTest {
 
     private void createFiles() throws IOException {
         final File baseDir = getFilesDir();
-        FileUtils.deleteDirectory(baseDir);
+        org.apache.commons.io.FileUtils.deleteDirectory(baseDir);
         FileUtils.mkdir(baseDir.getPath());
         final File aFile = new File(baseDir, A_PATH);
         FileUtils.mkdir(aFile.getParentFile().getPath());


### PR DESCRIPTION
Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.codehaus.plexus.PlexusFileUtilsRecipes%24DeleteDirectoryFileRecipe?organizationId=NzQ1YmJlODUtZjNkMy00OTNkLThhNDAtZWJmZDg4N2U1ZjU1