### PR TITLE
Restore the document titles dropped when the pages were ported

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus</artifactId>
-    <version>25</version>
+    <version>26</version>
   </parent>
 
   <artifactId>plexus-io</artifactId>

--- a/src/site/markdown/filemappers.md
+++ b/src/site/markdown/filemappers.md
@@ -1,3 +1,7 @@
+---
+title: File Mappers
+---
+
 # File Mappers
 
 A file mapper is a plexus component, which allows to convert file names. File mappers are used when creating files. For example, the [XML Maven Plugin](https://www.mojohaus.org/xml-maven-plugin) allows to specify a file mapper when creating files by XSLT transformation.

--- a/src/site/markdown/fileselectors.md
+++ b/src/site/markdown/fileselectors.md
@@ -1,3 +1,7 @@
+---
+title: File Selectors
+---
+
 # File Selectors
 
 A file selector is a plexus component, which allows to select certain files out of a given set. For example, the [Plexus Archiver](http://plexus.codehaus.org/plexus-archiver) uses file selectors to select the files being archived out of a base directory. Its counterpart, the Plexus Unarchiver allows to restrict the files to unarchive.

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -1,3 +1,7 @@
+---
+title: Introduction
+---
+
 # Plexus IO
 
 Plexus IO is a set of plexus components, which are designed for use in I/O operations. These I/O operations are doing nothing spectacular. For example, [Commons IO](http://jakarta.apache.org/commons/io) is a much more powerful library in the same area. However, the implementation as a plexus component allows reuse in Maven.


### PR DESCRIPTION
Unblocked by the release of plexus parent 26.

Each APT source opened with a title block. Converting the pages to Markdown dropped it, so
every generated page took its name from the project instead of the document. This puts the
titles back as YAML front matter.

It could not be done before now: parent 25 runs Spotless over `**/*.md`, and flexmark
rewrites the fence closing a front matter block, silently costing the page the very
metadata being restored. Parent 26 excludes `**/src/site/markdown/**`, so the first commit
is the parent upgrade.

Verified after the bump:

```
<title>File Mappers – Plexus IO Components</title>
<title>File Selectors – Plexus IO Components</title>
<title>Introduction – Plexus IO Components</title>
```

**Titles only.** None of `filemappers.apt`, `fileselectors.apt` or `index.apt` carried an
author or date block — each has a single dashed block, which APT reads as the title. I
checked the deleted sources rather than assuming, because a first pass at this had read the
body prose as an author list and produced twenty-odd bogus `author:` entries per page.